### PR TITLE
Don't emit a scroll when the listview is empty

### DIFF
--- a/library/src/main/java/com/melnykov/fab/AbsListViewScrollDetector.java
+++ b/library/src/main/java/com/melnykov/fab/AbsListViewScrollDetector.java
@@ -20,6 +20,7 @@ abstract class AbsListViewScrollDetector implements AbsListView.OnScrollListener
 
     @Override
     public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+        if(totalItemCount == 0) return;
         if (isSameRow(firstVisibleItem)) {
             int newScrollY = getTopItemScrollY();
             boolean isSignificantDelta = Math.abs(mLastScrollY - newScrollY) > mScrollThreshold;


### PR DESCRIPTION
The scrollstatelistener got confused with a listview became empty.
Not emitting a scroll when the itemcount is empty fixed it for me.