### PR TITLE
Fixed inconsistency with transparent background

### DIFF
--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -6,5 +6,5 @@
     <dimen name="fab_shadow_size">12dp</dimen>
 
     <dimen name="fab_scroll_threshold">4dp</dimen>
-    <dimen name="fab_elevation_lollipop">8dp</dimen>
+	<dimen name="fab_elevation_lollipop">30dp</dimen>
 </resources>


### PR DESCRIPTION
If you set the elevation to an insane amount the white circle goes away and i don't see any changes with the shadow
