### PR TITLE
ObservableScrollView can now accepts more than one listener

### DIFF
--- a/library/src/main/java/com/melnykov/fab/ObservableScrollView.java
+++ b/library/src/main/java/com/melnykov/fab/ObservableScrollView.java
@@ -1,17 +1,36 @@
 package com.melnykov.fab;
 
-
 import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.ScrollView;
 
-public class ObservableScrollView extends ScrollView {
+import java.util.ArrayList;
 
+/**
+ * A custom {@link ScrollView} that can accept a scroll change listener.
+ */
+public class ObservableScrollView extends ScrollView {
+    private ArrayList<OnScrollChangedListener> mCallbacks
+            = new ArrayList<OnScrollChangedListener>();
+
+    /**
+     * {@link ObservableScrollView} scroll changed listener
+     */
     public interface OnScrollChangedListener {
+        /**
+         * This is called in response to an internal scroll in this view (i.e., the
+         * view scrolled its own contents). This is typically as a result of
+         * {@link ScrollView#scrollBy(int, int)} or {@link ScrollView#scrollTo(int, int)} having been
+         * called.
+         *
+         * @param who owner of the event
+         * @param l Current horizontal scroll origin.
+         * @param t Current vertical scroll origin.
+         * @param oldl Previous horizontal scroll origin.
+         * @param oldt Previous vertical scroll origin.
+         */
         void onScrollChanged(ScrollView who, int l, int t, int oldl, int oldt);
     }
-
-    private OnScrollChangedListener mOnScrollChangedListener;
 
     public ObservableScrollView(Context context) {
         super(context);
@@ -28,12 +47,31 @@ public class ObservableScrollView extends ScrollView {
     @Override
     protected void onScrollChanged(int l, int t, int oldl, int oldt) {
         super.onScrollChanged(l, t, oldl, oldt);
-        if (mOnScrollChangedListener != null) {
-            mOnScrollChangedListener.onScrollChanged(this, l, t, oldl, oldt);
+        for (OnScrollChangedListener c : mCallbacks) {
+            c.onScrollChanged(this, l, t, oldl, oldt);
         }
     }
 
+    /**
+     * Adds given {@code listener} to callback list if not added before (not sets).
+     *
+     * @param listener {@link OnScrollChangedListener}
+     *
+     * @deprecated use {@link #addOnScrollChangedListener(OnScrollChangedListener)} instead
+     */
+    @Deprecated
     public void setOnScrollChangedListener(OnScrollChangedListener listener) {
-        mOnScrollChangedListener = listener;
+        addOnScrollChangedListener(listener);
+    }
+
+    /**
+     * Adds given {@code listener} to callback list if not added before.
+     *
+     * @param listener {@link OnScrollChangedListener}
+     */
+    public void addOnScrollChangedListener(OnScrollChangedListener listener) {
+        if (!mCallbacks.contains(listener)) {
+            mCallbacks.add(listener);
+        }
     }
 }


### PR DESCRIPTION
I needed this modification when I need to do extra scroll view related animations (i.e. for toolbar). Also, I think this is a solution for issue #75 but I am not sure since I don't know what is written over there.