### PR TITLE
Updated Gradle plugin, added retention to the TYPE IntDef, sample project updates, default pressed/ripple colors are adapted from the normal color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.0.1'
     }
 }
 

--- a/library/src/main/java/com/melnykov/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/melnykov/fab/FloatingActionButton.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.graphics.Outline;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
@@ -83,7 +84,7 @@ public class FloatingActionButton extends ImageButton {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         int size = getDimension(
-            mType == TYPE_NORMAL ? R.dimen.fab_size_normal : R.dimen.fab_size_mini);
+                mType == TYPE_NORMAL ? R.dimen.fab_size_normal : R.dimen.fab_size_mini);
         if (mShadow && !hasLollipopApi()) {
             size += mShadowSize * 2;
             setMarginsWithoutShadow();
@@ -94,8 +95,8 @@ public class FloatingActionButton extends ImageButton {
     private void init(Context context, AttributeSet attributeSet) {
         mVisible = true;
         mColorNormal = getColor(R.color.material_blue_500);
-        mColorPressed = getColor(R.color.material_blue_600);
-        mColorRipple = getColor(android.R.color.white);
+        mColorPressed = darkenColor(mColorNormal);
+        mColorRipple = lightenColor(mColorNormal);
         mType = TYPE_NORMAL;
         mShadow = true;
         mScrollThreshold = getResources().getDimensionPixelOffset(R.dimen.fab_scroll_threshold);
@@ -111,11 +112,11 @@ public class FloatingActionButton extends ImageButton {
         if (attr != null) {
             try {
                 mColorNormal = attr.getColor(R.styleable.FloatingActionButton_fab_colorNormal,
-                    getColor(R.color.material_blue_500));
+                        getColor(R.color.material_blue_500));
                 mColorPressed = attr.getColor(R.styleable.FloatingActionButton_fab_colorPressed,
-                    getColor(R.color.material_blue_600));
+                        darkenColor(mColorNormal));
                 mColorRipple = attr.getColor(R.styleable.FloatingActionButton_fab_colorRipple,
-                    getColor(android.R.color.white));
+                        lightenColor(mColorNormal));
                 mShadow = attr.getBoolean(R.styleable.FloatingActionButton_fab_shadow, true);
                 mType = attr.getInt(R.styleable.FloatingActionButton_fab_type, TYPE_NORMAL);
             } finally {
@@ -138,7 +139,7 @@ public class FloatingActionButton extends ImageButton {
 
         if (mShadow && !hasLollipopApi()) {
             Drawable shadowDrawable = getResources().getDrawable(mType == TYPE_NORMAL ? R.drawable.shadow
-                : R.drawable.shadow_mini);
+                    : R.drawable.shadow_mini);
             LayerDrawable layerDrawable = new LayerDrawable(new Drawable[]{shadowDrawable, shapeDrawable});
             layerDrawable.setLayerInset(1, mShadowSize, mShadowSize, mShadowSize, mShadowSize);
             return layerDrawable;
@@ -182,13 +183,13 @@ public class FloatingActionButton extends ImageButton {
             float elevation;
             if (mShadow) {
                 elevation = getElevation() > 0.0f ? getElevation()
-                    : getDimension(R.dimen.fab_elevation_lollipop);
+                        : getDimension(R.dimen.fab_elevation_lollipop);
             } else {
                 elevation = 0.0f;
             }
             setElevation(elevation);
             RippleDrawable rippleDrawable = new RippleDrawable(new ColorStateList(new int[][]{{}},
-                new int[]{mColorRipple}), drawable, null);
+                    new int[]{mColorRipple}), drawable, null);
             setOutlineProvider(new ViewOutlineProvider() {
                 @Override
                 public void getOutline(View view, Outline outline) {
@@ -326,8 +327,8 @@ public class FloatingActionButton extends ImageButton {
             int translationY = visible ? 0 : height + getMarginBottom();
             if (animate) {
                 ViewPropertyAnimator.animate(this).setInterpolator(mInterpolator)
-                    .setDuration(TRANSLATE_DURATION_MILLIS)
-                    .translationY(translationY);
+                        .setDuration(TRANSLATE_DURATION_MILLIS)
+                        .translationY(translationY);
             } else {
                 ViewHelper.setTranslationY(this, translationY);
             }
@@ -383,6 +384,20 @@ public class FloatingActionButton extends ImageButton {
 
     private boolean hasHoneycombApi() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+    }
+
+    private static int darkenColor(int color) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        hsv[2] *= 0.9f; // value component
+        return Color.HSVToColor(hsv);
+    }
+
+    private static int lightenColor(int color) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        hsv[2] *= 1.1f; // value component
+        return Color.HSVToColor(hsv);
     }
 
     private class AbsListViewScrollDetectorImpl extends AbsListViewScrollDetector {

--- a/library/src/main/java/com/melnykov/fab/FloatingActionButton.java
+++ b/library/src/main/java/com/melnykov/fab/FloatingActionButton.java
@@ -30,6 +30,9 @@ import android.widget.ImageButton;
 import com.nineoldandroids.view.ViewHelper;
 import com.nineoldandroids.view.ViewPropertyAnimator;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Android Google+ like floating action button which reacts on the attached list view scrolling events.
  *
@@ -38,6 +41,7 @@ import com.nineoldandroids.view.ViewPropertyAnimator;
 public class FloatingActionButton extends ImageButton {
     private static final int TRANSLATE_DURATION_MILLIS = 200;
 
+    @Retention(RetentionPolicy.SOURCE)
     @IntDef({TYPE_NORMAL, TYPE_MINI})
     public @interface TYPE {
     }

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -3,5 +3,4 @@
 <resources>
     <!-- http://www.google.com/design/spec/style/color.html#color-ui-color-palette -->
     <color name="material_blue_500">#5677fc</color>
-    <color name="material_blue_600">#4e6cef</color>
 </resources>

--- a/sample/src/main/res/values-v21/styles.xml
+++ b/sample/src/main/res/values-v21/styles.xml
@@ -4,5 +4,8 @@
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
+
+        <item name="android:navigationBarColor">@color/primary_dark</item>
     </style>
+
 </resources>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="primary">#3f51b5</color>
-    <color name="primary_pressed">#303f9f</color>
-    <color name="ripple">#ff80ab</color>
-    <color name="accent">#ff4081</color>
-    <color name="accent_pressed">#f50057</color>
+    <color name="primary_dark">#303f9f</color>
+    <color name="ripple">#F06292</color>
+    <color name="accent">#E91E63</color>
+    <color name="accent_pressed">#C2185B</color>
 </resources>


### PR DESCRIPTION
I updated the Gradle plugin to 1.0.1, and added Retention to the `TYPE` IntDef which avoids some issues that people had experienced with my material-dialogs library (wrong values would get uploaded to Maven). Also, I made it so that if the developer only specifies a normal color for the FAB, the pressed and ripple colors are automatically generated from the normal color (ripple is lighter version of normal, pressed is darker version of normal).

I also made the sample project's accent color Material pink 500 (which is the neutral level value, http://www.google.com/design/spec/style/color.html#color-color-palette), it looks more crisp. I made the navigation bar colored on Lollipop, too.
